### PR TITLE
Migrate application to FastAPI stack

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,50 +1,16 @@
-from flask import Flask
-from flask_cors import CORS
-import logging
-from config import config
+"""Compatibilidad para ejecutar la aplicación con `python app.py`."""
 
-def create_app(config_name='default'):
-    """
-    Factory function para crear la aplicación Flask
-    
-    Args:
-        config_name: Nombre de la configuración a usar
-        
-    Returns:
-        Instancia de Flask configurada
-    """
-    app = Flask(__name__)
-    app.config.from_object(config[config_name])
-    
-    # Configurar CORS
-    CORS(app, origins=["*"])
-    
-    # Configurar logging
-    configure_logging(app)
-    
-    # Registrar blueprints
-    register_blueprints(app)
-    
-    # Manejo de errores globales
-    register_error_handlers(app)
-    
-    return app
+from app.main import app
 
-def configure_logging(app):
-    """Configura el sistema de logging"""
-    if not app.debug and not app.testing:
-        logging.basicConfig(
-            level=logging.INFO,
-            format='%(asctime)s %(levelname)s: %(message)s [in %(pathname)s:%(lineno)d]'
-        )
-        app.logger.setLevel(logging.INFO)
+__all__ = ["app"]
 
-def register_blueprints(app):
-    """Registra todos los blueprints de la aplicación"""
-    from app.routes.advisor import advisor_bp
-    app.register_blueprint(advisor_bp, url_prefix='/api/v1')
+if __name__ == "__main__":
+    import uvicorn
+    from config import settings
 
-def register_error_handlers(app):
-    """Registra manejadores de errores globales"""
-    from app.utils.error_handlers import register_error_handlers as reg_handlers
-    reg_handlers(app)
+    uvicorn.run(
+        "app.main:app",
+        host=settings.api_host,
+        port=settings.api_port,
+        reload=settings.debug,
+    )

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,50 +1,40 @@
-from flask import Flask
-from flask_cors import CORS
 import logging
-from config import config
+from typing import Any
 
-def create_app(config_name='default'):
-    """
-    Factory function para crear la aplicación Flask
-    
-    Args:
-        config_name: Nombre de la configuración a usar
-        
-    Returns:
-        Instancia de Flask configurada
-    """
-    app = Flask(__name__)
-    app.config.from_object(config[config_name])
-    
-    # Configurar CORS
-    CORS(app, origins=["*"])
-    
-    # Configurar logging
-    configure_logging(app)
-    
-    # Registrar blueprints
-    register_blueprints(app)
-    
-    # Manejo de errores globales
-    register_error_handlers(app)
-    
-    return app
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
-def configure_logging(app):
-    """Configura el sistema de logging"""
-    if not app.debug and not app.testing:
-        logging.basicConfig(
-            level=logging.INFO,
-            format='%(asctime)s %(levelname)s: %(message)s [in %(pathname)s:%(lineno)d]'
-        )
-        app.logger.setLevel(logging.INFO)
+from config import settings
+from .routes.advisor import router as advisor_router
+from .utils.error_handlers import register_error_handlers
 
-def register_blueprints(app):
-    """Registra todos los blueprints de la aplicación"""
-    from app.routes.advisor import advisor_bp
-    app.register_blueprint(advisor_bp, url_prefix='/api/v1')
 
-def register_error_handlers(app):
-    """Registra manejadores de errores globales"""
-    from app.utils.error_handlers import register_error_handlers as reg_handlers
-    reg_handlers(app)
+def configure_logging(debug: bool) -> None:
+    """Configura el sistema de logging."""
+    log_level = logging.DEBUG if debug else logging.INFO
+    logging.basicConfig(
+        level=log_level,
+        format="%(asctime)s %(levelname)s: %(message)s [in %(pathname)s:%(lineno)d]",
+    )
+
+
+def create_app() -> FastAPI:
+    """Crea y configura la aplicación FastAPI."""
+    configure_logging(settings.debug)
+
+    fastapi_app = FastAPI(title=settings.app_name, version=settings.app_version)
+    fastapi_app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=False,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    fastapi_app.include_router(advisor_router)
+    register_error_handlers(fastapi_app)
+
+    return fastapi_app
+
+
+app: Any = create_app()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,3 @@
+from . import app
+
+__all__ = ["app"]

--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -1,115 +1,53 @@
-from marshmallow import Schema, fields, validate, ValidationError, post_load
-from typing import Dict, Any
+from datetime import datetime
+from typing import Any, Dict, List, Optional
 
-class ConsultaSchema(Schema):
- 
-    asesor = fields.Str(
-        required=True, 
-        validate=validate.Length(min=1, max=100),
-        error_messages={
-            'required': 'El campo asesor es requerido',
-            'invalid': 'El asesor debe ser una cadena de texto',
-            'length': 'El nombre del asesor debe tener entre 1 y 100 caracteres'
-        }
-    )
-    
-    contexto = fields.Str(
-        required=True, 
-        validate=validate.Length(min=1, max=2000),
-        error_messages={
-            'required': 'El campo contexto es requerido',
-            'invalid': 'El contexto debe ser una cadena de texto',
-            'length': 'El contexto debe tener entre 1 y 2000 caracteres'
-        }
-    )
-    
-    @post_load
-    def clean_data(self, data: Dict[str, Any], **kwargs) -> Dict[str, Any]:
-        """Limpia y normaliza los datos después de la validación"""
-        # Limpiar espacios en blanco
-        data['asesor'] = data['asesor'].strip()
-        data['contexto'] = data['contexto'].strip()
-        
-        return data
-    
-    class Meta:
-        strict = True
+from pydantic import BaseModel, Field, field_validator
 
-class RespuestaSchema(Schema):
-    """
-    Schema para la respuesta del asesor
-    
-    Campos:
-        success: Indica si la operación fue exitosa
-        motivo: Motivo de la consulta (opcional)
-        mensaje: Mensaje procesado para WhatsApp (opcional)
-        mensaje_original: Mensaje original sin procesar (opcional)
-        error: Mensaje de error (opcional)
-        raw_response: Respuesta cruda en caso de error (opcional)
-    """
-    success = fields.Bool(
-        required=True,
-        error_messages={
-            'required': 'El campo success es requerido',
-            'invalid': 'El campo success debe ser un booleano'
-        }
-    )
-    
-    motivo = fields.Str(
-        allow_none=True,
-        validate=validate.Length(max=200),
-        error_messages={
-            'invalid': 'El motivo debe ser una cadena de texto',
-            'length': 'El motivo no puede exceder 200 caracteres'
-        }
-    )
-    
-    mensaje = fields.Str(
-        allow_none=True,
-        validate=validate.Length(max=1000),
-        error_messages={
-            'invalid': 'El mensaje debe ser una cadena de texto',
-            'length': 'El mensaje no puede exceder 1000 caracteres'
-        }
-    )
-    
-    mensaje_original = fields.Str(
-        allow_none=True,
-        validate=validate.Length(max=1000),
-        error_messages={
-            'invalid': 'El mensaje original debe ser una cadena de texto',
-            'length': 'El mensaje original no puede exceder 1000 caracteres'
-        }
-    )
-    
-    error = fields.Str(
-        allow_none=True,
-        validate=validate.Length(max=500),
-        error_messages={
-            'invalid': 'El error debe ser una cadena de texto',
-            'length': 'El mensaje de error no puede exceder 500 caracteres'
-        }
-    )
-    
-    raw_response = fields.Str(
-        allow_none=True,
-        validate=validate.Length(max=2000),
-        error_messages={
-            'invalid': 'La respuesta cruda debe ser una cadena de texto',
-            'length': 'La respuesta cruda no puede exceder 2000 caracteres'
-        }
-    )
 
-class ErrorSchema(Schema):
-    """Schema para respuestas de error estandarizadas"""
-    success = fields.Bool(required=True, default=False)
-    error = fields.Str(required=True)
-    code = fields.Int(allow_none=True)
-    details = fields.Raw(allow_none=True)
+class ConsultaRequest(BaseModel):
+    asesor: str = Field(..., min_length=1, max_length=100, description="Nombre del asesor")
+    contexto: str = Field(..., min_length=1, max_length=2000, description="Contexto de la consulta")
 
-class HealthSchema(Schema):
-    """Schema para el endpoint de health check"""
-    status = fields.Str(required=True)
-    service = fields.Str(required=True)
-    version = fields.Str(required=True)
-    timestamp = fields.DateTime(allow_none=True)
+    @field_validator("asesor", "contexto")
+    @classmethod
+    def strip_values(cls, value: str) -> str:
+        return value.strip()
+
+
+class AdvisorResponse(BaseModel):
+    success: bool
+    motivo: Optional[str] = Field(default=None, max_length=200)
+    mensaje: Optional[str] = Field(default=None, max_length=1000)
+    mensaje_original: Optional[str] = Field(default=None, max_length=1000)
+    error: Optional[str] = Field(default=None, max_length=500)
+    raw_response: Optional[str] = Field(default=None, max_length=2000)
+
+
+class ErrorResponse(BaseModel):
+    success: bool = False
+    error: str
+    code: Optional[int] = None
+    details: Optional[Any] = None
+
+
+class HealthResponse(BaseModel):
+    status: str
+    service: str
+    version: str
+    timestamp: datetime
+
+
+class TestOpenAIResponse(BaseModel):
+    openai_status: str
+    test_result: AdvisorResponse
+
+
+class ContextExample(BaseModel):
+    descripcion: str
+    asesor: str
+    contexto: str
+
+
+class EjemploContextoResponse(BaseModel):
+    ejemplos: List[ContextExample]
+    formato_requerido: Dict[str, str]

--- a/app/routes/advisor.py
+++ b/app/routes/advisor.py
@@ -1,194 +1,181 @@
-from flask import Blueprint, request, jsonify, current_app
-from marshmallow import ValidationError
 from datetime import datetime
 import logging
+from typing import Annotated
 
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.concurrency import run_in_threadpool
+
+from config import Settings, get_settings
+from ..models.schemas import (
+    AdvisorResponse,
+    ConsultaRequest,
+    EjemploContextoResponse,
+    ErrorResponse,
+    HealthResponse,
+    TestOpenAIResponse,
+)
 from ..services.openai_service import OpenAIService
-from ..models.schemas import ConsultaSchema, RespuestaSchema, ErrorSchema, HealthSchema
 
-advisor_bp = Blueprint('advisor', __name__)
+router = APIRouter(prefix="/api/v1", tags=["advisor"])
 logger = logging.getLogger(__name__)
 
-@advisor_bp.route('/health', methods=['GET'])
-def health_check():
-    """
-    Endpoint de health check
-    
-    Returns:
-        JSON con el estado del servicio
-    """
-    try:
-        health_data = {
-            "status": "healthy",
-            "service": "Yamaha Advisor API",
-            "version": "1.0.0",
-            "timestamp": datetime.utcnow()
-        }
-        
-        # Validar respuesta
-        schema = HealthSchema()
-        validated_response = schema.dump(health_data)
-        
-        return jsonify(validated_response), 200
-        
-    except Exception as e:
-        logger.error(f"Error en health check: {str(e)}")
-        return jsonify({
-            "status": "unhealthy",
-            "service": "Yamaha Advisor API",
-            "error": str(e)
-        }), 500
 
-@advisor_bp.route('/generar-respuesta', methods=['POST'])
-def generar_respuesta():
-   
+def get_openai_service(settings: Annotated[Settings, Depends(get_settings)]) -> OpenAIService:
+    return OpenAIService(settings=settings)
+
+
+@router.get("/health", response_model=HealthResponse)
+async def health_check(settings: Annotated[Settings, Depends(get_settings)]) -> HealthResponse:
+    """Endpoint de health check."""
+
     try:
-        # Validar que el request tiene JSON
-        if not request.is_json:
-            return _create_error_response(
-                "Content-Type debe ser application/json", 
-                400, 
-                {"content_type": request.content_type}
-            )
-        
-        # Validar datos de entrada
-        schema = ConsultaSchema()
-        data = schema.load(request.json)
-        
-        # Validar que OpenAI esté configurado
-        if not current_app.config.get('OPENAI_API_KEY'):
-            return _create_error_response(
-                "Servicio no configurado correctamente",
-                503,
-                {"missing": "OPENAI_API_KEY"}
-            )
-        
-        # Generar respuesta
-        openai_service = OpenAIService()
-        resultado = openai_service.generate_advisor_response(
-            asesor=data['asesor'],
-            contexto=data['contexto']
+        return HealthResponse(
+            status="healthy",
+            service=settings.app_name,
+            version=settings.app_version,
+            timestamp=datetime.utcnow(),
         )
-        
-        # Validar y serializar respuesta
-        response_schema = RespuestaSchema()
-        validated_response = response_schema.dump(resultado)
-        
-        # Log de éxito
-        status_code = 200 if resultado['success'] else 422
-        logger.info(f"Respuesta generada para asesor: {data['asesor']}, success: {resultado['success']}")
-        
-        return jsonify(validated_response), status_code
-        
-    except ValidationError as e:
-        logger.warning(f"Error de validación: {e.messages}")
-        return _create_error_response(
-            "Datos de entrada inválidos",
-            400,
-            e.messages
-        )
-        
-    except Exception as e:
-        logger.error(f"Error interno en generar_respuesta: {str(e)}", exc_info=True)
-        return _create_error_response(
-            "Error interno del servidor",
-            500,
-            str(e) if current_app.debug else None
+    except Exception as exc:  # pragma: no cover - fallback in caso improbable
+        logger.error("Error en health check: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=ErrorResponse(
+                error="Error interno del servidor",
+                code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                details=str(exc),
+            ).model_dump(),
+        ) from exc
+
+
+@router.post(
+    "/generar-respuesta",
+    response_model=AdvisorResponse,
+    responses={
+        status.HTTP_400_BAD_REQUEST: {"model": ErrorResponse},
+        status.HTTP_503_SERVICE_UNAVAILABLE: {"model": ErrorResponse},
+        status.HTTP_500_INTERNAL_SERVER_ERROR: {"model": ErrorResponse},
+    },
+)
+async def generar_respuesta(
+    consulta: ConsultaRequest,
+    openai_service: Annotated[OpenAIService, Depends(get_openai_service)],
+) -> AdvisorResponse:
+    """Genera la respuesta del asesor utilizando OpenAI."""
+
+    if not openai_service.api_key:
+        logger.error("OpenAI API key no configurada")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=ErrorResponse(
+                error="Servicio no configurado correctamente",
+                code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                details={"missing": "OPENAI_API_KEY"},
+            ).model_dump(),
         )
 
-@advisor_bp.route('/ejemplo-contexto', methods=['GET'])
-def ejemplo_contexto():
-    """
-    Endpoint que devuelve ejemplos de contexto válidos
-    
-    Returns:
-        JSON con ejemplos de uso
-    """
+    try:
+        resultado = await run_in_threadpool(
+            openai_service.generate_advisor_response,
+            consulta.asesor,
+            consulta.contexto,
+        )
+    except ValueError as exc:
+        logger.warning("Error de validación de configuración: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=ErrorResponse(
+                error=str(exc),
+                code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            ).model_dump(),
+        ) from exc
+    except Exception as exc:
+        logger.error("Error interno en generar_respuesta: %s", exc, exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=ErrorResponse(
+                error="Error interno del servidor",
+                code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                details=str(exc),
+            ).model_dump(),
+        ) from exc
+
+    logger.info(
+        "Respuesta generada para asesor %s, success: %s",
+        consulta.asesor,
+        resultado.get("success"),
+    )
+
+    return AdvisorResponse(**resultado)
+
+
+@router.get("/ejemplo-contexto", response_model=EjemploContextoResponse)
+async def ejemplo_contexto() -> EjemploContextoResponse:
+    """Devuelve ejemplos de contexto válidos."""
+
     ejemplos = {
         "ejemplos": [
             {
                 "descripcion": "Consulta por repuestos",
                 "asesor": "Andrea Gómez",
-                "contexto": "nombre_cliente: 'Juan Pérez', sucursal: 'Yamaha Aceitar 134', repuesto/equipamiento_interes: 'bujías', motivo: 'repuestos_equipamiento', tipo_consulta: 'repuesto'"
+                "contexto": "nombre_cliente: 'Juan Pérez', sucursal: 'Yamaha Aceitar 134', repuesto/equipamiento_interes: 'bujías', motivo: 'repuestos_equipamiento', tipo_consulta: 'repuesto'",
             },
             {
                 "descripcion": "Consulta por servicio técnico",
                 "asesor": "Carlos Rodríguez",
-                "contexto": "nombre_cliente: 'María González', sucursal: 'Yamaha Centro', repuesto/equipamiento_interes: 'revisión motor', motivo: 'servicio_tecnico', tipo_consulta: 'mantenimiento'"
+                "contexto": "nombre_cliente: 'María González', sucursal: 'Yamaha Centro', repuesto/equipamiento_interes: 'revisión motor', motivo: 'servicio_tecnico', tipo_consulta: 'mantenimiento'",
             },
             {
                 "descripcion": "Consulta general",
                 "asesor": "Ana Silva",
-                "contexto": "nombre_cliente: 'Cliente', sucursal: 'Yamaha Norte', repuesto/equipamiento_interes: 'información general', motivo: 'consulta_general', tipo_consulta: 'informacion'"
-            }
+                "contexto": "nombre_cliente: 'Cliente', sucursal: 'Yamaha Norte', repuesto/equipamiento_interes: 'información general', motivo: 'consulta_general', tipo_consulta: 'informacion'",
+            },
         ],
         "formato_requerido": {
             "asesor": "string (1-100 caracteres)",
-            "contexto": "string (1-2000 caracteres)"
-        }
+            "contexto": "string (1-2000 caracteres)",
+        },
     }
-    
-    return jsonify(ejemplos), 200
 
-@advisor_bp.route('/test-openai', methods=['POST'])
-def test_openai():
-    """
-    Endpoint para probar la conexión con OpenAI (solo en desarrollo)
-    
-    Returns:
-        JSON con el estado de la conexión
-    """
-    if not current_app.debug:
-        return _create_error_response("Endpoint solo disponible en modo debug", 403)
-    
-    try:
-        # Test básico con datos mínimos
-        openai_service = OpenAIService()
-        resultado = openai_service.generate_advisor_response(
-            asesor="Test",
-            contexto="nombre_cliente: 'Test', motivo: 'test'"
-        )
-        
-        return jsonify({
-            "openai_status": "OK",
-            "test_result": resultado
-        }), 200
-        
-    except Exception as e:
-        logger.error(f"Error en test OpenAI: {str(e)}")
-        return _create_error_response(
-            "Error en conexión con OpenAI",
-            503,
-            str(e)
+    return EjemploContextoResponse(**ejemplos)
+
+
+@router.post(
+    "/test-openai",
+    response_model=TestOpenAIResponse,
+    responses={
+        status.HTTP_403_FORBIDDEN: {"model": ErrorResponse},
+        status.HTTP_503_SERVICE_UNAVAILABLE: {"model": ErrorResponse},
+    },
+)
+async def test_openai(
+    settings: Annotated[Settings, Depends(get_settings)],
+    openai_service: Annotated[OpenAIService, Depends(get_openai_service)],
+) -> TestOpenAIResponse:
+    """Endpoint para probar la conexión con OpenAI (solo en desarrollo)."""
+
+    if not settings.debug:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=ErrorResponse(
+                error="Endpoint solo disponible en modo debug",
+                code=status.HTTP_403_FORBIDDEN,
+            ).model_dump(),
         )
 
-def _create_error_response(message: str, status_code: int, details=None):
-    """
-    Crea una respuesta de error estandarizada
-    
-    Args:
-        message: Mensaje de error
-        status_code: Código de estado HTTP
-        details: Detalles adicionales del error
-        
-    Returns:
-        Tupla (response, status_code)
-    """
-    error_data = {
-        "success": False,
-        "error": message,
-        "code": status_code,
-        "details": details
-    }
-    
-    try:
-        error_schema = ErrorSchema()
-        validated_error = error_schema.dump(error_data)
-        return jsonify(validated_error), status_code
-    except Exception:
-        # Fallback en caso de error en la validación
-        return jsonify({
-            "success": False,
-            "error": message,
-            "code": status_code
-        }), status_code
+    resultado = await run_in_threadpool(
+        openai_service.generate_advisor_response,
+        "Test",
+        "nombre_cliente: 'Test', motivo: 'test'",
+    )
+
+    if not resultado.get("success"):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=ErrorResponse(
+                error="Error en conexión con OpenAI",
+                code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                details=resultado.get("raw_response"),
+            ).model_dump(),
+        )
+
+    return TestOpenAIResponse(openai_status="OK", test_result=AdvisorResponse(**resultado))

--- a/app/services/openai_service.py
+++ b/app/services/openai_service.py
@@ -1,38 +1,45 @@
-import requests
 import json
 import logging
-from flask import current_app
-from typing import Dict, Any, Optional
+from typing import Any, Dict
+
+import requests
+
+from config import Settings
+
 
 class OpenAIService:
-    """Servicio para manejar interacciones con OpenAI API"""
-    
-    def __init__(self):
-        self.api_key = current_app.config['OPENAI_API_KEY']
-        self.url = current_app.config['OPENAI_URL']
-        self.model = current_app.config['OPENAI_MODEL']
-        self.temperature = current_app.config['OPENAI_TEMPERATURE']
+    """Servicio para manejar interacciones con la API de OpenAI."""
+
+    def __init__(self, settings: Settings):
+        self._settings = settings
+        self.api_key = settings.openai_api_key
+        self.url = settings.openai_url
+        self.model = settings.openai_model
+        self.temperature = settings.openai_temperature
+        self.timeout = settings.openai_timeout
+        self.max_tokens = settings.openai_max_tokens
         self.logger = logging.getLogger(__name__)
-    
+
     def _get_headers(self) -> Dict[str, str]:
-        """Obtiene headers para la API de OpenAI"""
+        """Obtiene headers para la API de OpenAI."""
         return {
             "Authorization": f"Bearer {self.api_key}",
-            "Content-Type": "application/json"
+            "Content-Type": "application/json",
         }
-    
+
     def _create_prompt(self, asesor: str, contexto: str) -> str:
-        """Crea el prompt para OpenAI"""
+        """Crea el prompt para OpenAI."""
         return f"""Debes responder SOLO con un JSON válido con esta estructura exacta:
 {{
-  "motivo": "resumen corto del motivo de la consulta",
-  "mensaje": "respuesta del asesor",
-  "mensaje_original": "mensaje formateado para WhatsApp"
+  \"motivo\": \"resumen corto del motivo de la consulta\",
+  \"mensaje\": \"respuesta del asesor\",
+  \"mensaje_original\": \"mensaje formateado para WhatsApp\"
 }}
 
 Instrucciones:
 - motivo: Resumen fiel usando palabras del cliente
-- mensaje: 1) Saludo con nombre del cliente (si es nombre real, corregir ortografía), 2) Presentación con mi nombre como asesor, 3) Confirmación de TODA la información recibida del cliente (incluir TODO: productos, tallas, especificaciones, condiciones de pago, urgencia, etc.), 4) Pregunta de seguimiento. NO incluir nombre del asesor al final.
+- mensaje: 1) Saludo con nombre del cliente (si es nombre real, corregir ortografía), 2) Presentación con mi nombre como asesor,
+ 3) Confirmación de TODA la información recibida del cliente (incluir TODO: productos, tallas, especificaciones, condiciones de pago, urgencia, etc.), 4) Pregunta de seguimiento. NO incluir nombre del asesor al final.
 - mensaje_original: Mismo mensaje con formato WhatsApp:
   * *texto* solo para nombres propios (cliente y asesor)
   * • para listas de información
@@ -46,98 +53,71 @@ Contexto: {contexto}
 
 Responde SOLO el JSON:"""
 
-    
     def generate_advisor_response(self, asesor: str, contexto: str) -> Dict[str, Any]:
-        """
-        Genera respuesta del asesor usando OpenAI
-        
-        Args:
-            asesor: Nombre del asesor
-            contexto: Contexto de la consulta del cliente
-            
-        Returns:
-            Dict con la respuesta procesada
-            
-        Raises:
-            ValueError: Si la API key no está configurada
-            Exception: Si hay errores de comunicación o procesamiento
-        """
-        try:
-            self._validate_config()
-            
-            prompt = self._create_prompt(asesor, contexto)
-            data = self._prepare_request_data(prompt)
-            
-            self.logger.info(f"Enviando solicitud a OpenAI para asesor: {asesor}")
-            
-            response = self._make_api_request(data)
-            mensaje_raw = response['choices'][0]['message']['content']
-            
-            return self._process_response(mensaje_raw)
-            
-        except requests.exceptions.RequestException as e:
-            self.logger.error(f"Error en solicitud a OpenAI: {str(e)}")
-            raise Exception(f"Error de comunicación con OpenAI: {str(e)}")
-        except Exception as e:
-            self.logger.error(f"Error procesando respuesta de OpenAI: {str(e)}")
-            raise Exception(f"Error procesando respuesta: {str(e)}")
-    
-    def _validate_config(self):
-        """Valida que la configuración esté completa"""
+        """Genera respuesta del asesor usando OpenAI."""
+        self._validate_config()
+
+        prompt = self._create_prompt(asesor, contexto)
+        data = self._prepare_request_data(prompt)
+
+        self.logger.info("Enviando solicitud a OpenAI para asesor: %s", asesor)
+
+        response = self._make_api_request(data)
+        mensaje_raw = response["choices"][0]["message"]["content"]
+
+        return self._process_response(mensaje_raw)
+
+    def _validate_config(self) -> None:
+        """Valida que la configuración esté completa."""
         if not self.api_key:
             raise ValueError("OpenAI API key no configurada")
-    
+
     def _prepare_request_data(self, prompt: str) -> Dict[str, Any]:
-        """Prepara los datos para la solicitud a OpenAI"""
-        return {
+        """Prepara los datos para la solicitud a OpenAI."""
+        payload: Dict[str, Any] = {
             "model": self.model,
             "messages": [
                 {
-                    "role": "system", 
-                    "content": "Eres un asesor profesional de Yamaha Aceitar. Solo responde con un JSON válido."
+                    "role": "system",
+                    "content": "Eres un asesor profesional de Yamaha Aceitar. Solo responde con un JSON válido.",
                 },
-                {"role": "user", "content": prompt}
+                {"role": "user", "content": prompt},
             ],
-            "temperature": self.temperature
+            "temperature": self.temperature,
         }
-    
+
+        if self.max_tokens:
+            payload["max_tokens"] = self.max_tokens
+
+        return payload
+
     def _make_api_request(self, data: Dict[str, Any]) -> Dict[str, Any]:
-        """Realiza la solicitud HTTP a OpenAI"""
+        """Realiza la solicitud HTTP a OpenAI."""
         response = requests.post(
-            self.url, 
-            headers=self._get_headers(), 
+            self.url,
+            headers=self._get_headers(),
             json=data,
-            timeout=30
+            timeout=self.timeout,
         )
         response.raise_for_status()
         return response.json()
-    
+
     def _process_response(self, mensaje_raw: str) -> Dict[str, Any]:
-        """
-        Procesa la respuesta cruda de OpenAI
-        
-        Args:
-            mensaje_raw: Respuesta cruda de OpenAI
-            
-        Returns:
-            Dict con la respuesta procesada
-        """
+        """Procesa la respuesta cruda de OpenAI."""
         try:
             json_data = json.loads(mensaje_raw)
-            
+
             return {
                 "success": True,
                 "motivo": json_data["motivo"],
                 "mensaje": json_data["mensaje"],
-                "mensaje_original": json_data["mensaje_original"]
+                "mensaje_original": json_data["mensaje_original"],
             }
-            
-        except json.JSONDecodeError as e:
-            self.logger.warning(f"Respuesta no es JSON válido: {str(e)}")
-            self.logger.warning(f"Respuesta recibida: {mensaje_raw[:500]}...")  # Solo primeros 500 chars
+        except json.JSONDecodeError as exc:
+            self.logger.warning("Respuesta no es JSON válido: %s", exc)
+            self.logger.warning("Respuesta recibida: %s...", mensaje_raw[:500])
             return {
                 "success": False,
-                "error": f"Respuesta no es JSON válido: {str(e)}",
-                "raw_response": mensaje_raw
+                "error": f"Respuesta no es JSON válido: {exc}",
+                "raw_response": mensaje_raw,
             }
-    

--- a/app/utils/error_handlers.py
+++ b/app/utils/error_handlers.py
@@ -1,169 +1,39 @@
-from flask import jsonify, request, current_app
 import logging
-from werkzeug.exceptions import HTTPException
+from typing import Any
+
+from fastapi import FastAPI, HTTPException, Request, status
+from fastapi.responses import JSONResponse
+
+from app.models.schemas import ErrorResponse
 
 logger = logging.getLogger(__name__)
 
-def register_error_handlers(app):
-    """
-    Registra manejadores de errores globales para la aplicación
-    
-    Args:
-        app: Instancia de Flask
-    """
-    
-    @app.errorhandler(400)
-    def bad_request(error):
-        """Maneja errores 400 - Bad Request"""
-        logger.warning(f"Bad request: {request.url} - {str(error)}")
-        return jsonify({
-            "success": False,
-            "error": "Solicitud incorrecta",
-            "code": 400,
-            "details": str(error.description) if hasattr(error, 'description') else None
-        }), 400
-    
-    @app.errorhandler(404)
-    def not_found(error):
-        """Maneja errores 404 - Not Found"""
-        logger.warning(f"Endpoint no encontrado: {request.url}")
-        return jsonify({
-            "success": False,
-            "error": "Endpoint no encontrado",
-            "code": 404,
-            "path": request.path,
-            "method": request.method
-        }), 404
-    
-    @app.errorhandler(405)
-    def method_not_allowed(error):
-        """Maneja errores 405 - Method Not Allowed"""
-        logger.warning(f"Método no permitido: {request.method} {request.url}")
-        return jsonify({
-            "success": False,
-            "error": "Método no permitido",
-            "code": 405,
-            "method": request.method,
-            "path": request.path,
-            "allowed_methods": error.valid_methods if hasattr(error, 'valid_methods') else None
-        }), 405
-    
-    @app.errorhandler(415)
-    def unsupported_media_type(error):
-        """Maneja errores 415 - Unsupported Media Type"""
-        logger.warning(f"Tipo de contenido no soportado: {request.content_type}")
-        return jsonify({
-            "success": False,
-            "error": "Tipo de contenido no soportado",
-            "code": 415,
-            "content_type": request.content_type,
-            "expected": "application/json"
-        }), 415
-    
-    @app.errorhandler(422)
-    def unprocessable_entity(error):
-        """Maneja errores 422 - Unprocessable Entity"""
-        logger.warning(f"Entidad no procesable: {request.url}")
-        return jsonify({
-            "success": False,
-            "error": "Datos no procesables",
-            "code": 422,
-            "details": str(error.description) if hasattr(error, 'description') else None
-        }), 422
-    
-    @app.errorhandler(429)
-    def too_many_requests(error):
-        """Maneja errores 429 - Too Many Requests"""
-        logger.warning(f"Demasiadas solicitudes desde: {request.remote_addr}")
-        return jsonify({
-            "success": False,
-            "error": "Demasiadas solicitudes",
-            "code": 429,
-            "message": "Por favor, inténtalo más tarde"
-        }), 429
-    
-    @app.errorhandler(500)
-    def internal_error(error):
-        """Maneja errores 500 - Internal Server Error"""
-        logger.error(f"Error interno del servidor: {str(error)}", exc_info=True)
-        
-        # En producción, no revelar detalles del error
-        details = None
-        if current_app.debug:
-            details = str(error)
-        
-        return jsonify({
-            "success": False,
-            "error": "Error interno del servidor",
-            "code": 500,
-            "details": details
-        }), 500
-    
-    @app.errorhandler(502)
-    def bad_gateway(error):
-        """Maneja errores 502 - Bad Gateway"""
-        logger.error(f"Bad gateway: {str(error)}")
-        return jsonify({
-            "success": False,
-            "error": "Error de gateway",
-            "code": 502,
-            "message": "Servicio temporalmente no disponible"
-        }), 502
-    
-    @app.errorhandler(503)
-    def service_unavailable(error):
-        """Maneja errores 503 - Service Unavailable"""
-        logger.error(f"Servicio no disponible: {str(error)}")
-        return jsonify({
-            "success": False,
-            "error": "Servicio no disponible",
-            "code": 503,
-            "message": "Por favor, inténtalo más tarde"
-        }), 503
-    
-    @app.errorhandler(HTTPException)
-    def handle_http_exception(error):
-        """Maneja cualquier otra excepción HTTP"""
-        logger.warning(f"Excepción HTTP {error.code}: {request.url}")
-        return jsonify({
-            "success": False,
-            "error": error.name,
-            "code": error.code,
-            "description": error.description
-        }), error.code
-    
-    @app.errorhandler(Exception)
-    def handle_generic_exception(error):
-        """Maneja excepciones genéricas no capturadas"""
-        logger.error(f"Excepción no manejada: {str(error)}", exc_info=True)
-        
-        # En producción, no revelar detalles del error
-        details = None
-        if current_app.debug:
-            details = {
-                "type": type(error).__name__,
-                "message": str(error)
-            }
-        
-        return jsonify({
-            "success": False,
-            "error": "Error interno del servidor",
-            "code": 500,
-            "details": details
-        }), 500
-    
-    # Manejar errores de JSON inválido
-    @app.errorhandler(400)
-    def handle_json_error(error):
-        """Maneja errores específicos de JSON malformado"""
-        if "Failed to decode JSON object" in str(error):
-            logger.warning(f"JSON malformado en solicitud: {request.url}")
-            return jsonify({
-                "success": False,
-                "error": "JSON malformado",
-                "code": 400,
-                "message": "Verifica que el JSON esté bien formateado"
-            }), 400
-        
-        # Si no es un error de JSON, usar el manejador por defecto
-        return bad_request(error)
+
+def register_error_handlers(app: FastAPI) -> None:
+    """Registra manejadores de errores globales para la aplicación FastAPI."""
+
+    @app.exception_handler(HTTPException)
+    async def http_exception_handler(request: Request, exc: HTTPException) -> JSONResponse:
+        logger.warning("Excepción HTTP %s en %s", exc.status_code, request.url.path)
+
+        detail: Any
+        if isinstance(exc.detail, dict):
+            detail = exc.detail
+        else:
+            detail = ErrorResponse(
+                error=str(exc.detail),
+                code=exc.status_code,
+            ).model_dump()
+
+        return JSONResponse(status_code=exc.status_code, content=detail)
+
+    @app.exception_handler(Exception)
+    async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+        logger.error("Excepción no manejada en %s: %s", request.url.path, exc, exc_info=True)
+
+        error = ErrorResponse(
+            error="Error interno del servidor",
+            code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            details=str(exc),
+        )
+        return JSONResponse(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, content=error.model_dump())

--- a/config.py
+++ b/config.py
@@ -1,42 +1,35 @@
-import os
-from dotenv import load_dotenv
+from functools import lru_cache
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
-# Cargar variables del archivo .env
-load_dotenv()
 
-class Config:
-    """Configuración base de la aplicación"""
-    SECRET_KEY = os.environ.get('SECRET_KEY')
-    OPENAI_API_KEY = os.environ.get('OPENAI_API_KEY')
-    OPENAI_URL = "https://api.openai.com/v1/chat/completions"
-    OPENAI_MODEL = os.environ.get('OPENAI_MODEL') or "gpt-3.5-turbo"
-    OPENAI_TEMPERATURE = float(os.environ.get('OPENAI_TEMPERATURE', 0.2))
-    OPENAI_TIMEOUT = int(os.environ.get('OPENAI_TIMEOUT', 30))
-    OPENAI_MAX_TOKENS = int(os.environ.get('OPENAI_MAX_TOKENS', 1000))
-    
-    # Información de la app
-    APP_NAME = os.environ.get('APP_NAME', 'Yamaha Advisor API')
-    APP_VERSION = os.environ.get('APP_VERSION', '1.0.0')
+class Settings(BaseSettings):
+    """Application configuration loaded from environment variables."""
 
-class DevelopmentConfig(Config):
-    """Configuración para desarrollo"""
-    DEBUG = True
-    TESTING = False
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
 
-class ProductionConfig(Config):
-    """Configuración para producción"""
-    DEBUG = False
-    TESTING = False
+    environment: str = Field(default="development", alias="ENVIRONMENT")
+    debug: bool = Field(default=False, alias="DEBUG")
 
-class TestingConfig(Config):
-    """Configuración para testing"""
-    DEBUG = True
-    TESTING = True
-    OPENAI_API_KEY = "test-key"
+    app_name: str = Field(default="Yamaha Advisor API", alias="APP_NAME")
+    app_version: str = Field(default="1.0.0", alias="APP_VERSION")
 
-config = {
-    'development': DevelopmentConfig,
-    'production': ProductionConfig,
-    'testing': TestingConfig,
-    'default': DevelopmentConfig
-}
+    api_host: str = Field(default="0.0.0.0", alias="API_HOST")
+    api_port: int = Field(default=8000, alias="API_PORT")
+
+    openai_api_key: str | None = Field(default=None, alias="OPENAI_API_KEY")
+    openai_url: str = Field(default="https://api.openai.com/v1/chat/completions", alias="OPENAI_URL")
+    openai_model: str = Field(default="gpt-3.5-turbo", alias="OPENAI_MODEL")
+    openai_temperature: float = Field(default=0.2, alias="OPENAI_TEMPERATURE")
+    openai_timeout: int = Field(default=30, alias="OPENAI_TIMEOUT")
+    openai_max_tokens: int = Field(default=1000, alias="OPENAI_MAX_TOKENS")
+
+
+@lru_cache()
+def get_settings() -> "Settings":
+    """Return a cached settings instance for dependency injection."""
+
+    return Settings()
+
+
+settings = get_settings()

--- a/dockerfile
+++ b/dockerfile
@@ -3,10 +3,10 @@ FROM python:3.11-slim
 WORKDIR /app
 
 COPY requirements.txt .
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-EXPOSE 5051
+EXPOSE 8000
 
-CMD ["gunicorn", "--bind", "0.0.0.0:5051", "--workers", "4", "run:app"]
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@
 fastapi==0.110.0
 uvicorn[standard]==0.27.1
 requests==2.31.0
-pydantic==2.6.3
-pydantic-settings==2.1.0
+pydantic>=2.8.2,<3.0
+pydantic-settings>=2.1.0,<3.0
 
 # Testing
 pytest==7.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,10 @@
 # Dependencias principales
-Flask==2.3.3
-Flask-CORS==4.0.0
+fastapi==0.110.0
+uvicorn[standard]==0.27.1
 requests==2.31.0
-marshmallow==3.20.1
+pydantic==2.6.3
+pydantic-settings==2.1.0
 
-# Para manejar variables de entorno desde archivo .env
-python-dotenv==1.0.0
-
-# Servidor de producción
-gunicorn==21.2.0
-
-# Testing (opcional)
+# Testing
 pytest==7.4.0
-pytest-flask==1.2.0
+httpx==0.26.0

--- a/run.py
+++ b/run.py
@@ -1,51 +1,12 @@
+import uvicorn
 
-import os
-import sys
-from app import create_app
+from config import settings
 
-def main():
-    config_name = os.environ.get('FLASK_ENV', 'development')
-    
-    if config_name not in ['development', 'production', 'testing']:
-        print(f"Error: Configuración '{config_name}' no válida")
-        print("Configuraciones válidas: development, production, testing")
-        sys.exit(1)
-    
-    try:
-        app = create_app(config_name)
-        
-        port = int(os.environ.get('PORT', 5000))
-        host = os.environ.get('HOST', '0.0.0.0')
-        if not app.config.get('OPENAI_API_KEY'):
-            print("⚠️  ADVERTENCIA: OPENAI_API_KEY no configurada")
-            print("La aplicación se iniciará pero las solicitudes fallarán")
-        print(f"🚀 Iniciando Yamaha Advisor API")
-        print(f"   Entorno: {config_name}")
-        print(f"   Host: {host}")
-        print(f"   Puerto: {port}")
-        print(f"   Debug: {app.config['DEBUG']}")
-        print(f"   URL: http://{host}:{port}")
-        app.run(
-            host=host, 
-            port=port, 
-            debug=app.config['DEBUG'],
-            threaded=True
-        )
-    except KeyboardInterrupt:
-        print("\n👋 Aplicación detenida por el usuario")
-        sys.exit(0)
-    except Exception as e:
-        print(f"❌ Error iniciando la aplicación: {str(e)}")
-        sys.exit(1)
-def create_app_for_wsgi():
-    """
-    Función para crear la app en entornos WSGI (Gunicorn, uWSGI, etc.)
-    
-    Returns:
-        Flask app instance
-    """
-    config_name = os.environ.get('FLASK_ENV', 'production')
-    return create_app(config_name)
-app = create_app_for_wsgi()
-if __name__ == '__main__':
-    main()
+
+if __name__ == "__main__":
+    uvicorn.run(
+        "app.main:app",
+        host=settings.api_host,
+        port=settings.api_port,
+        reload=settings.debug,
+    )

--- a/tests/test_advisor.py
+++ b/tests/test_advisor.py
@@ -1,0 +1,34 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_health_endpoint_returns_service_status():
+    response = client.get("/api/v1/health")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "healthy"
+    assert payload["service"]
+    assert payload["version"]
+    assert "timestamp" in payload
+
+
+def test_generar_respuesta_without_api_key_returns_503():
+    response = client.post(
+        "/api/v1/generar-respuesta",
+        json={"asesor": "Ana", "contexto": "Consulta de prueba"},
+    )
+    assert response.status_code == 503
+    payload = response.json()
+    assert payload["error"] == "Servicio no configurado correctamente"
+
+
+def test_ejemplo_contexto_returns_examples():
+    response = client.get("/api/v1/ejemplo-contexto")
+    assert response.status_code == 200
+    payload = response.json()
+    assert "ejemplos" in payload
+    assert isinstance(payload["ejemplos"], list)
+    assert payload["ejemplos"], "Se esperaba al menos un ejemplo"


### PR DESCRIPTION
## Summary
- replace the legacy Flask factory with a FastAPI application and configure CORS and shared error handlers
- refactor advisor routes to async FastAPI endpoints backed by Pydantic request/response models and injectable OpenAI service
- introduce settings via `pydantic-settings`, update container/entrypoint tooling, and add FastAPI-oriented tests

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi' – dependencies unavailable in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8471e4a588332b4fef85ed4ed3a6e